### PR TITLE
feat: add intlayer mcp server

### DIFF
--- a/public/servers/en/intlayer.md
+++ b/public/servers/en/intlayer.md
@@ -1,0 +1,126 @@
+---
+name: Intlayer MCP Server
+digest: The Intlayer MCP server integrates AI assistance into your IDE for a smarter, context-aware development experience with Intlayer. It provides command-line access, in-project documentation, and intuitive AI help.
+author: aymericzip
+homepage: https://intlayer.org
+repository: https://github.com/aymericzip/intlayer
+capabilities:
+  prompts: true
+  resources: true
+  tools: true
+tags:
+  - intlayer
+  - i18n
+  - l10n
+  - localization
+  - translation
+  - ide
+  - automation
+  - documentation
+icon: https://intlayer.org/android-chrome-512x512.png
+createTime: 2025-06-10
+---
+
+A Model Context Protocol (MCP) server that enhances development with **Intlayer** by providing IDE-aware documentation, CLI integration, and AI-powered context tools.
+
+## Features
+
+- AI-assisted suggestions and explanations for Intlayer usage
+- Smart CLI integration to run and inspect `intlayer` commands directly from your IDE
+- In-context documentation based on your project's actual Intlayer version
+- Tool interface and prompt suggestions for real-time interaction
+- Zero-config setup with `npx`
+
+## Supported IDEs
+
+- Cursor
+- VS Code (via MCP)
+- Any IDE supporting the Model Context Protocol (MCP)
+
+## Setup
+
+### Option 1: Quick Start with NPX
+
+Add the following to your `.cursor/mcp.json` (or equivalent MCP config):
+
+```json
+{
+  "mcpServers": {
+    "intlayer": {
+      "command": "npx",
+      "args": ["-y", "@intlayer/mcp"]
+    }
+  }
+}
+```
+
+Then restart your IDE or MCP session.
+
+### Option 2: VS Code Configuration
+
+Create `.vscode/mcp.json`:
+
+```json
+{
+  "servers": {
+    "intlayer": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@intlayer/mcp"]
+    }
+  }
+}
+```
+
+In the Command Palette:
+
+- Enable **Agent Mode** via "Chat Mode"
+- Use `#intlayer` to reference tools
+- Manage tool confirmations and server sessions
+
+## CLI Usage
+
+You can also run the Intlayer MCP Server manually via CLI:
+
+```bash
+# Recommended: npx
+npx @intlayer/mcp
+
+# Dev Mode
+npm run dev
+
+# Custom entry
+node dist/cjs/index.cjs
+```
+
+To inspect and debug:
+
+```bash
+npx @modelcontextprotocol/inspector npx @intlayer/mcp
+```
+
+## Available Features
+
+| Feature                | Description                                                          |
+| ---------------------- | -------------------------------------------------------------------- |
+| Smart CLI              | Inline execution and doc lookup for `intlayer` commands              |
+| Versioned Docs         | Auto-detects your installed Intlayer version and loads matching docs |
+| Autocomplete + Prompts | AI-assisted prompt suggestions tailored to your file and context     |
+| Agent Mode Tools       | Register and run custom tools inside Cursor and compatible IDEs      |
+
+## Prerequisites
+
+- Node.js
+- An IDE that supports the MCP protocol (Cursor, VS Code, etc.)
+- A project using [Intlayer](https://github.com/aymericzip/intlayer)
+
+## License
+
+Apache 2.0
+
+---
+
+## Useful Links
+
+- [Intlayer GitHub Repository](https://github.com/aymericzip/intlayer)
+- [Documentation](https://intlayer.org/doc/mcp-server)

--- a/public/servers/ko/intlayer.md
+++ b/public/servers/ko/intlayer.md
@@ -1,0 +1,126 @@
+---
+name: Intlayer MCP 서버
+digest: Intlayer MCP 서버는 IDE에 AI 지원을 통합하여 Intlayer를 사용한 더 스마트하고 컨텍스트를 인식하는 개발 경험을 제공합니다. 명령줄 액세스, 프로젝트 내 문서 및 직관적인 AI 도움말을 제공합니다.
+author: aymericzip
+homepage: https://intlayer.org
+repository: https://github.com/aymericzip/intlayer
+capabilities:
+  prompts: true
+  resources: true
+  tools: true
+tags:
+  - intlayer
+  - i18n
+  - l10n
+  - localization
+  - translation
+  - ide
+  - automation
+  - documentation
+icon: https://intlayer.org/android-chrome-512x512.png
+createTime: 2025-06-10
+---
+
+**Intlayer**를 사용하여 개발을 향상시키는 모델 컨텍스트 프로토콜(MCP) 서버로, IDE 인식 문서, CLI 통합 및 AI 기반 컨텍스트 도구를 제공합니다.
+
+## 기능
+
+- Intlayer 사용에 대한 AI 지원 제안 및 설명
+- IDE에서 직접 `intlayer` 명령을 실행하고 검사하는 스마트 CLI 통합
+- 프로젝트의 실제 Intlayer 버전을 기반으로 한 컨텍스트 내 문서
+- 실시간 상호 작용을 위한 도구 인터페이스 및 프롬프트 제안
+- `npx`를 사용한 제로 구성 설정
+
+## 지원되는 IDE
+
+- Cursor
+- VS Code (MCP를 통해)
+- 모델 컨텍스트 프로토콜(MCP)을 지원하는 모든 IDE
+
+## 설정
+
+### 옵션 1: NPX로 빠른 시작
+
+`.cursor/mcp.json`(또는 동등한 MCP 구성)에 다음을 추가하십시오:
+
+```json
+{
+  "mcpServers": {
+    "intlayer": {
+      "command": "npx",
+      "args": ["-y", "@intlayer/mcp"]
+    }
+  }
+}
+```
+
+그런 다음 IDE 또는 MCP 세션을 다시 시작하십시오.
+
+### 옵션 2: VS Code 구성
+
+`.vscode/mcp.json`을 만듭니다:
+
+```json
+{
+  "servers": {
+    "intlayer": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@intlayer/mcp"]
+    }
+  }
+}
+```
+
+명령 팔레트에서:
+
+- "채팅 모드"를 통해 **에이전트 모드** 활성화
+- `#intlayer`를 사용하여 도구 참조
+- 도구 확인 및 서버 세션 관리
+
+## CLI 사용법
+
+CLI를 통해 수동으로 Intlayer MCP 서버를 실행할 수도 있습니다:
+
+```bash
+# 권장: npx
+npx @intlayer/mcp
+
+# 개발 모드
+npm run dev
+
+# 사용자 지정 항목
+node dist/cjs/index.cjs
+```
+
+검사 및 디버그하려면:
+
+```bash
+npx @modelcontextprotocol/inspector npx @intlayer/mcp
+```
+
+## 사용 가능한 기능
+
+| 기능                 | 설명                                                                |
+| -------------------- | ------------------------------------------------------------------- |
+| 스마트 CLI           | `intlayer` 명령에 대한 인라인 실행 및 문서 조회                     |
+| 버전 관리된 문서     | 설치된 Intlayer 버전을 자동으로 감지하고 일치하는 문서를 로드합니다 |
+| 자동 완성 + 프롬프트 | 파일 및 컨텍스트에 맞는 AI 지원 프롬프트 제안                       |
+| 에이전트 모드 도구   | Cursor 및 호환 IDE 내에서 사용자 지정 도구를 등록하고 실행합니다    |
+
+## 전제 조건
+
+- Node.js
+- MCP 프로토콜을 지원하는 IDE (Cursor, VS Code 등)
+- [Intlayer](https://github.com/aymericzip/intlayer)를 사용하는 프로젝트
+
+## 라이선스
+
+Apache 2.0
+
+---
+
+## 유용한 링크
+
+- [Intlayer GitHub 리포지토리](https://github.com/aymericzip/intlayer)
+- [문서](https://intlayer.org/doc/mcp-server)

--- a/public/servers/tw/intlayer.md
+++ b/public/servers/tw/intlayer.md
@@ -1,0 +1,126 @@
+---
+name: Intlayer MCP 伺服器
+digest: Intlayer MCP 伺服器將 AI 輔助功能整合到您的 IDE 中，透過 Intlayer 提供更智慧、具有上下文感知能力的開發體驗。它提供命令列存取、專案内文件和直觀的 AI 協助。
+author: aymericzip
+homepage: https://intlayer.org
+repository: https://github.com/aymericzip/intlayer
+capabilities:
+  prompts: true
+  resources: true
+  tools: true
+tags:
+  - intlayer
+  - i18n
+  - l10n
+  - 本地化
+  - 翻譯
+  - ide
+  - 自動化
+  - 文件
+icon: https://intlayer.org/android-chrome-512x512.png
+createTime: 2025-06-10
+---
+
+一個模型上下文協定（MCP）伺服器，透過提供 IDE 感知的文件、CLI 整合和 AI 驅動的上下文工具來增強 **Intlayer** 的開發體驗。
+
+## 特性
+
+- 為 Intlayer 使用提供 AI 輔助的建議和解釋
+- 智慧 CLI 整合，可直接在您的 IDE 中執行和檢查 `intlayer` 命令
+- 基於您專案實際 Intlayer 版本的上下文文件
+- 用於即時互動的工具介面和提示建議
+- 使用 `npx` 實現零設定設置
+
+## 支援的 IDE
+
+- Cursor
+- VS Code (透過 MCP)
+- 任何支援模型上下文協定（MCP）的 IDE
+
+## 設定
+
+### 選項 1：使用 NPX 快速啟動
+
+將以下內容新增至您的 `.cursor/mcp.json`（或等效的 MCP 設定）中：
+
+```json
+{
+  "mcpServers": {
+    "intlayer": {
+      "command": "npx",
+      "args": ["-y", "@intlayer/mcp"]
+    }
+  }
+}
+```
+
+然後重新啟動您的 IDE 或 MCP 會話。
+
+### 選項 2：VS Code 設定
+
+建立 `.vscode/mcp.json`：
+
+```json
+{
+  "servers": {
+    "intlayer": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@intlayer/mcp"]
+    }
+  }
+}
+```
+
+在命令面板中：
+
+- 透過「聊天模式」啟用 **代理模式**
+- 使用 `#intlayer` 來參照工具
+- 管理工具確認和伺服器會話
+
+## CLI 用法
+
+您也可以透過 CLI 手動執行 Intlayer MCP 伺服器：
+
+```bash
+# 推薦：npx
+npx @intlayer/mcp
+
+# 開發模式
+npm run dev
+
+# 自訂入口
+node dist/cjs/index.cjs
+```
+
+要進行檢查和偵錯：
+
+```bash
+npx @modelcontextprotocol/inspector npx @intlayer/mcp
+```
+
+## 可用功能
+
+| 功能            | 描述                                           |
+| --------------- | ---------------------------------------------- |
+| 智慧 CLI        | `intlayer` 命令的內嵌執行和文件查詢            |
+| 版本化文件      | 自動偵測您安裝的 Intlayer 版本並載入相符的文件 |
+| 自動完成 + 提示 | 針對您的檔案和上下文量身訂製的 AI 輔助提示建議 |
+| 代理模式工具    | 在 Cursor 和相容的 IDE 中註冊並執行自訂工具    |
+
+## 先決條件
+
+- Node.js
+- 支援 MCP 協定的 IDE（Cursor、VS Code 等）
+- 使用 [Intlayer](https://github.com/aymericzip/intlayer) 的專案
+
+## 授權條款
+
+Apache 2.0
+
+---
+
+## 有用連結
+
+- [Intlayer GitHub 倉庫](https://github.com/aymericzip/intlayer)
+- [文件](https://intlayer.org/doc/mcp-server)

--- a/public/servers/zh/intlayer.md
+++ b/public/servers/zh/intlayer.md
@@ -1,0 +1,126 @@
+---
+name: Intlayer MCP 服务器
+digest: Intlayer MCP 服务器将 AI 辅助功能集成到您的 IDE 中，通过 Intlayer 提供更智能、具有上下文感知能力的开发体验。它提供命令行访问、项目内文档和直观的 AI 帮助。
+author: aymericzip
+homepage: https://intlayer.org
+repository: https://github.com/aymericzip/intlayer
+capabilities:
+  prompts: true
+  resources: true
+  tools: true
+tags:
+  - intlayer
+  - i18n
+  - l10n
+  - 本地化
+  - 翻译
+  - ide
+  - 自动化
+  - 文档
+icon: https://intlayer.org/android-chrome-512x512.png
+createTime: 2025-06-10
+---
+
+一个模型上下文协议（MCP）服务器，通过提供 IDE 感知的文档、CLI 集成和 AI 驱动的上下文工具来增强 **Intlayer** 的开发体验。
+
+## 特性
+
+- 为 Intlayer 使用提供 AI 辅助的建议和解释
+- 智能 CLI 集成，可直接在您的 IDE 中运行和检查 `intlayer` 命令
+- 基于您项目实际 Intlayer 版本的上下文文档
+- 用于实时交互的工具界面和提示建议
+- 使用 `npx` 实现零配置设置
+
+## 支持的 IDE
+
+- Cursor
+- VS Code (通过 MCP)
+- 任何支持模型上下文协议（MCP）的 IDE
+
+## 设置
+
+### 选项 1：使用 NPX 快速启动
+
+将以下内容添加到您的 `.cursor/mcp.json`（或等效的 MCP 配置）中：
+
+```json
+{
+  "mcpServers": {
+    "intlayer": {
+      "command": "npx",
+      "args": ["-y", "@intlayer/mcp"]
+    }
+  }
+}
+```
+
+然后重新启动您的 IDE 或 MCP 会话。
+
+### 选项 2：VS Code 配置
+
+创建 `.vscode/mcp.json`：
+
+```json
+{
+  "servers": {
+    "intlayer": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@intlayer/mcp"]
+    }
+  }
+}
+```
+
+在命令面板中：
+
+- 通过“聊天模式”启用 **代理模式**
+- 使用 `#intlayer` 来引用工具
+- 管理工具确认和服务器会话
+
+## CLI 用法
+
+您也可以通过 CLI 手动运行 Intlayer MCP 服务器：
+
+```bash
+# 推荐：npx
+npx @intlayer/mcp
+
+# 开发模式
+npm run dev
+
+# 自定义入口
+node dist/cjs/index.cjs
+```
+
+要进行检查和调试：
+
+```bash
+npx @modelcontextprotocol/inspector npx @intlayer/mcp
+```
+
+## 可用功能
+
+| 功能            | 描述                                           |
+| --------------- | ---------------------------------------------- |
+| 智能 CLI        | `intlayer` 命令的内联执行和文档查询            |
+| 版本化文档      | 自动检测您安装的 Intlayer 版本并加载匹配的文档 |
+| 自动完成 + 提示 | 针对您的文件和上下文量身定制的 AI 辅助提示建议 |
+| 代理模式工具    | 在 Cursor 和兼容的 IDE 中注册并运行自定义工具  |
+
+## 先决条件
+
+- Node.js
+- 支持 MCP 协议的 IDE（Cursor、VS Code 等）
+- 使用 [Intlayer](https://github.com/aymericzip/intlayer) 的项目
+
+## 许可证
+
+Apache 2.0
+
+---
+
+## 有用链接
+
+- [Intlayer GitHub 仓库](https://github.com/aymericzip/intlayer)
+- [文档](https://intlayer.org/doc/mcp-server)


### PR DESCRIPTION
# [@intlayer/mcp](https://www.npmjs.com/package/@intlayer/mcp) – MCP server for i18n / CMS solution 

The `@intlayer/mcp` server offers seamless IDE integration for developers using [Intlayer](https://github.com/aymericzip/intlayer), an internationalization library tailored for modern JavaScript and TypeScript projects using AI.

By connecting your IDE to this MCP server (e.g., in [Cursor](https://www.cursor.so)), you get instant access to:

 **CLI integration** – Inline guidance and command completion for Intlayer’s CLI tooling. (list / build / pull / push / fill dictionaries)
***Integrated access to the documentation** – Provide access to the Intlayer doc to the IDE

 – To add into your `.cursor/mcp.json`.

Ideal for teams working with multilingual content, component-based architectures, and modern frameworks like Next.js. Perfectly bridges AI and content localization.