### PR TITLE
Add Pylon MCP Server — x402 utility APIs for AI agents

### DIFF
--- a/public/servers/en/pylon-mcp.md
+++ b/public/servers/en/pylon-mcp.md
@@ -1,0 +1,48 @@
+---
+name: Pylon
+digest: x402-payable utility APIs for AI agents — web extraction, search, translation, code execution, image generation, and more
+author: Pylon AI
+homepage: https://pylonapi.com
+repository: https://github.com/pylon-apis/pylon-mcp
+capabilities:
+  tools: true
+tags:
+  - x402
+  - api
+  - web-extraction
+  - search
+  - translation
+  - code-execution
+  - image-generation
+  - micropayments
+icon: https://pylonapi.com/favicon.ico
+createTime: 2026-02-18
+---
+
+An MCP server providing 20 x402-payable utility APIs for AI agents. Pay-per-use with USDC on Base — no API keys, no signup required.
+
+## Capabilities
+
+- **Web Extraction** — Extract clean content from any URL
+- **Web Search** — Search the web with structured results
+- **Translation** — Translate text between languages
+- **Code Execution** — Run code snippets safely
+- **Image Generation** — Generate images from text prompts
+- **Email Send** — Send emails programmatically
+- And 14 more utility capabilities
+
+## Installation
+
+```bash
+npx @pylonapi/mcp@latest
+```
+
+## How It Works
+
+Pylon uses the x402 protocol — HTTP-native micropayments via USDC on Base. Your agent discovers a capability, pays a fraction of a cent, and gets the result. No API keys to manage, no billing dashboards, no rate limit negotiations.
+
+## Links
+
+- [Website](https://pylonapi.com)
+- [npm](https://www.npmjs.com/package/@pylonapi/mcp)
+- [GitHub](https://github.com/pylon-apis/pylon-mcp)


### PR DESCRIPTION
Adds Pylon MCP Server to the directory.

**Pylon** provides 20 x402-payable utility APIs for AI agents: web extraction, search, translation, code execution, image generation, and more. Pay-per-use with USDC on Base — no API keys needed.

- **npm:** `npx @pylonapi/mcp@latest`
- **GitHub:** https://github.com/pylon-apis/pylon-mcp
- **Website:** https://pylonapi.com