### PR TITLE
Add Roundtable MCP Server

### DIFF
--- a/public/servers/en/roundtable.md
+++ b/public/servers/en/roundtable.md
@@ -1,6 +1,6 @@
 ---
 name: Roundtable
-digest: Your AI Board of Directors — run multi-model debates and get synthesized insights
+digest: Multi-model AI debates — GPT-4o, Claude, Gemini & 200+ models discuss, then synthesize insight
 author: Deadpixel
 homepage: https://roundtable.now
 repository: https://github.com/deadpixel/roundtable-dashboard
@@ -30,8 +30,8 @@ An MCP server that gives you access to a multi-model AI board of directors. Run 
 
 ## Tools
 
-- **consult**
-  - Run a full roundtable debate with multiple AI models
+- **consult_council**
+  - Get perspectives from multiple AI models on any topic through structured multi-model debate
   - Inputs:
     - `prompt` (string): Your question or topic for discussion
 
@@ -41,14 +41,14 @@ An MCP server that gives you access to a multi-model AI board of directors. Run 
     - `code` (string): The code to review
     - `context` (string, optional): Additional context about the code
 
-- **debug**
-  - Collaborative multi-model debugging session
+- **debug_issue**
+  - Debug issues using multiple AI models to analyze the problem from different angles
   - Inputs:
     - `issue` (string): Description of the bug or issue
     - `code` (string, optional): Relevant code snippets
 
-- **architect**
-  - Multi-model system design discussion
+- **design_architecture**
+  - Get architectural recommendations from multiple AI models for system design decisions
   - Inputs:
     - `requirements` (string): System requirements and constraints
 

--- a/public/servers/en/roundtable.md
+++ b/public/servers/en/roundtable.md
@@ -1,0 +1,92 @@
+---
+name: Roundtable
+digest: Your AI Board of Directors — run multi-model debates and get synthesized insights
+author: Deadpixel
+homepage: https://roundtable.now
+repository: https://github.com/deadpixel/roundtable-dashboard
+capabilities:
+  resources: false
+  tools: true
+  prompts: false
+tags:
+  - ai
+  - multi-model
+  - debate
+  - reasoning
+  - code-review
+  - architecture
+icon: https://roundtable.now/logo-512.png
+createTime: 2026-03-01
+---
+
+An MCP server that gives you access to a multi-model AI board of directors. Run structured debates where GPT-4o, Claude, Gemini, DeepSeek, and 200+ other models discuss your question, then a moderator synthesizes all perspectives into actionable insight.
+
+## Features
+
+- **Multi-Model Reasoning**: Get diverse perspectives from 200+ AI models on any question
+- **Structured Debates**: Models discuss, critique, and build on each other's ideas
+- **Moderator Synthesis**: A dedicated moderator distills all perspectives into clear recommendations
+- **6 Specialized Tools**: Purpose-built tools for different use cases
+
+## Tools
+
+- **consult**
+  - Run a full roundtable debate with multiple AI models
+  - Inputs:
+    - `prompt` (string): Your question or topic for discussion
+
+- **review_code**
+  - Get multi-model code review from different perspectives
+  - Inputs:
+    - `code` (string): The code to review
+    - `context` (string, optional): Additional context about the code
+
+- **debug**
+  - Collaborative multi-model debugging session
+  - Inputs:
+    - `issue` (string): Description of the bug or issue
+    - `code` (string, optional): Relevant code snippets
+
+- **architect**
+  - Multi-model system design discussion
+  - Inputs:
+    - `requirements` (string): System requirements and constraints
+
+- **plan_implementation**
+  - Get implementation plans from multiple model perspectives
+  - Inputs:
+    - `task` (string): The feature or task to plan
+
+- **assess_tradeoffs**
+  - Multi-model tradeoff analysis for technical decisions
+  - Inputs:
+    - `decision` (string): The decision and options to evaluate
+
+## Configuration
+
+### Usage with Claude Desktop / Claude Code
+
+Add this to your MCP configuration:
+
+```json
+{
+  "mcpServers": {
+    "roundtable": {
+      "url": "https://mcp.roundtable.now/mcp",
+      "headers": {
+        "X-API-Key": "YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+
+### Getting an API Key
+
+1. Visit [roundtable.now/settings](https://roundtable.now/settings)
+2. Navigate to API Keys
+3. Generate a new key
+
+## License
+
+This MCP server is proprietary. See the [Roundtable website](https://roundtable.now) for terms of service.


### PR DESCRIPTION
## Add Roundtable MCP Server

**Roundtable** is a multi-model AI debate platform where GPT-4o, Claude, Gemini & 200+ models discuss your question collaboratively, then a moderator synthesizes all perspectives into actionable insight.

- **Repository**: https://github.com/deadpixel/roundtable-dashboard
- **Website**: https://roundtable.now
- **MCP Endpoint**: `https://mcp.roundtable.now/mcp` (Streamable HTTP)
- **Auth**: API Key (`rpnd_` prefix)

### MCP Tools (13 total)

| Tool | Description |
|------|-------------|
| `consult_council` | Multi-model roundtable discussion on any question |
| `review_code` | Multi-perspective code review |
| `debug_issue` | Multi-angle bug diagnosis |
| `design_architecture` | Architecture design council |
| `plan_implementation` | Implementation planning with consensus |
| `assess_tradeoffs` | Evaluate technical tradeoffs |
| `check_usage` | Check credits and rate limits |
| `list_models` | List available AI models |
| `list_sessions` | List past debate sessions |
| `get_session` | Retrieve session results |
| `get_thread_link` | Get shareable thread link |
| `set_thread_visibility` | Toggle thread visibility |
| `get_logs` | View invocation logs |

### Key Features
- Auto-mode: AI picks optimal models, roles, and conversation mode
- Configurable thinking levels (low/medium/high)
- Session persistence and thread sharing
- 3 built-in prompts, 3 resources