### PR TITLE
Update Hive Intelligence description to current positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The following MCP servers are currently documented on the website:
 - **Git** - Git repository operations and management
 - **GitHub** - GitHub API integration for repository management
 - **Google Drive** - Access and management of Google Drive files
-- **[Hive Intelligence](https://github.com/hive-intel/hive-crypto-mcp)** - Ultimate cryptocurrency MCP for AI assistants with unified access to crypto, DeFi, and Web3 analytics
+- **[Hive Intelligence](https://github.com/hive-intel/hive-crypto-mcp)** - Institutional-grade crypto market infrastructure for AI — live prices, DeFi, wallets, and token risk through a managed MCP, REST API, or CLI.
 - **[Linked API MCP](https://github.com/Linked-API/linkedapi-mcp)** - MCP server that lets AI assistants control LinkedIn accounts and retrieve real-time data
 - **[Keboola MCP](https://www.claudemcp.com/servers/keboola-mcp)** - 
 - **Playwright** - Browser automation and testing


### PR DESCRIPTION
Refreshes Hive Intelligence's description to match the current canonical product positioning on [hiveintelligence.xyz](https://hiveintelligence.xyz) and the `hive-intel/hive-crypto-mcp` repo's updated GitHub description.

**What Hive is** (unchanged): managed crypto-market infrastructure that gives AI agents one endpoint for live crypto prices, DeFi activity, wallet positions, and token risk across every major chain. Works with Claude Desktop, Claude Code, Cursor, ChatGPT Desktop, Windsurf, VS Code (GitHub Copilot Chat), Gemini CLI, and any MCP-compatible client.

**Changes**:
- Description rewritten to reflect current positioning.
- Now calls out REST API and CLI alongside MCP, since Hive exposes three surfaces on the same endpoint.

No structural changes — same link, same bold formatting, same position.