### PR TITLE
Add Ignav Flights MCP server

### DIFF
--- a/public/servers/en/ignav-flights.md
+++ b/public/servers/en/ignav-flights.md
@@ -1,0 +1,33 @@
+---
+name: Ignav Flights
+digest: Live flight prices, booking links, and airport lookup for AI agents and travel apps.
+author: Gus Gordon
+homepage: https://ignav.com/docs/mcp
+repository: https://github.com/gusgordon/ignav-skill
+capabilities:
+  resources: false
+  tools: true
+tags:
+  - travel
+  - flights
+  - booking
+  - remote
+icon: https://raw.githubusercontent.com/gusgordon/ignav-skill/main/assets/logo.png
+createTime: 2026-06-17
+featured: false
+---
+
+Ignav Flights is a hosted MCP server providing live flight data, working booking links, and airport lookup for AI agents and travel apps.
+
+**Features:**
+- Live flight prices
+- Detailed itineraries
+- Working booking links
+- Airport search and lookup
+
+**Tools:**
+- `search_airports`: Find airports by name, city, or airport code.
+- `search_flights`: Get live flight prices and booking links.
+
+**Usage:**
+Use the remote MCP endpoint: [https://ignav.com/mcp](https://ignav.com/mcp)


### PR DESCRIPTION
This PR adds Ignav Flights, a hosted MCP server providing live flight prices, itinerary details, booking links, and airport lookup for AI agents and travel apps.

Homepage: https://ignav.com/docs/mcp  
Repository: https://github.com/gusgordon/ignav-skill  
Remote endpoint: https://ignav.com/mcp