### PR TITLE
Add Xquik MCP server and fix localized canonicals

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ We welcome contributions to the Claude MCP Community website! Here are ways you 
 ### Contributing Servers
 
 1. Fork the repository
-2. Create a new file in the `/servers/{locale}` directory following the existing format
+2. Create a new file in the `/public/servers/{locale}` directory following the existing format
 3. Submit a pull request with your server information
 
 Alternatively, use the "Submit a Server" button on the [Servers page](https://www.claudemcp.com/servers) to create a pull request directly.

--- a/README_CN.md
+++ b/README_CN.md
@@ -98,7 +98,7 @@ yarn dev
 ### 贡献服务器
 
 1. Fork 仓库
-2. 在 `/servers/{locale}` 目录下创建一个新文件，遵循现有格式
+2. 在 `/public/servers/{locale}` 目录下创建一个新文件，遵循现有格式
 3. 提交一个包含您的服务器信息的 PR 请求
 
 或者，使用 [Servers 页面](https://www.claudemcp.com/servers) 上的 "Submit a Server" 按钮直接创建一个 PR。

--- a/public/servers/en/xquik.md
+++ b/public/servers/en/xquik.md
@@ -1,0 +1,59 @@
+---
+name: Xquik MCP Server
+digest: Search and monitor public X data through a remote MCP endpoint
+author: Xquik
+homepage: https://docs.xquik.com/mcp/overview
+repository: https://github.com/Xquik-dev/x-twitter-scraper
+capabilities:
+  prompts: false
+  resources: false
+  tools: true
+tags:
+  - x
+  - twitter
+  - search
+  - monitoring
+  - webhooks
+  - api
+icon: https://xquik.com/icons/mcp/xquik.png
+createTime: 2026-07-10T00:00:00Z
+---
+
+Xquik provides a remote Streamable HTTP MCP server for public X data workflows.
+Its MCP tools expose API discovery and execution for search, extraction,
+monitoring, webhooks, and approved write actions.
+
+## Connect
+
+Use the remote endpoint with an Xquik API key:
+
+```json
+{
+  "mcpServers": {
+    "xquik": {
+      "url": "https://xquik.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${XQUIK_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+Keep `XQUIK_API_KEY` in your MCP client's secret store or environment
+configuration. Do not commit it to a repository.
+
+## Workflow Guidance
+
+- Start with read-only discovery, search, extraction, and monitoring calls.
+- Review endpoint schemas before supplying parameters.
+- Require explicit user approval before posting, replying, uploading media, or
+  changing account state.
+- Preserve source URLs, handles, timestamps, and collection times when using
+  public posts as evidence.
+
+## Links
+
+- [MCP setup documentation](https://docs.xquik.com/mcp/overview)
+- [MCP discovery metadata](https://xquik.com/.well-known/mcp.json)
+- [Source repository](https://github.com/Xquik-dev/x-twitter-scraper)

--- a/public/servers/en/xquik.md
+++ b/public/servers/en/xquik.md
@@ -33,7 +33,7 @@ Use the remote endpoint with an Xquik API key:
     "xquik": {
       "url": "https://xquik.com/mcp",
       "headers": {
-        "Authorization": "Bearer ${XQUIK_API_KEY}"
+        "x-api-key": "${XQUIK_API_KEY}"
       }
     }
   }

--- a/public/servers/en/xquik.md
+++ b/public/servers/en/xquik.md
@@ -57,3 +57,5 @@ configuration. Do not commit it to a repository.
 - [MCP setup documentation](https://docs.xquik.com/mcp/overview)
 - [MCP discovery metadata](https://xquik.com/.well-known/mcp.json)
 - [Source repository](https://github.com/Xquik-dev/x-twitter-scraper)
+
+Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -63,7 +63,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
       images: ['/og.png'],
     },
     alternates: {
-        canonical: locale === 'en' ? `https://www.claube.ai` : `https://www.www.claube.ai/${locale}`,
+      canonical: locale === 'en' ? `https://www.claube.ai` : `https://www.claube.ai/${locale}`,
     },
     manifest: "/site.webmanifest",
   };
@@ -130,4 +130,4 @@ export default async function Home({ params }: PageProps) {
       </Suspense>
     </main>
   );
-} 
+}


### PR DESCRIPTION
## Summary

- Add an English Xquik MCP server page with searchable metadata and remote endpoint setup.
- Use the current `x-api-key` header and safe secret-handling guidance.
- Correct the server contribution path in both English and Chinese READMEs.
- Fix invalid localized homepage canonicals containing a duplicated `www` segment.
- Add the required Xquik independence notice.

## Independent Repository Fix

The localized homepage metadata previously generated URLs such as `https://www.www.claube.ai/zh`. The repair emits `https://www.claube.ai/{locale}` and preserves the existing English canonical. This issue is independent of the Xquik listing.

## Validation

- TypeScript check passed
- Repository lint completed with 6 unrelated existing warnings
- Production build passed twice and generated 390 static pages
- Xquik frontmatter and content assertions passed
- Markdown link check passed
- Direct HTTP checks passed for every Xquik link
- Generated `/en/servers/xquik` HTML, RSC, and metadata files verified
- Localized canonical output verified for `zh`, `tw`, and `ko`
- Clean merge simulation and diff checks passed

The Vercel status requires the repository owner to update GitHub App permissions. It is not a code or build failure.

Disclosure: I am affiliated with Xquik.

Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.
